### PR TITLE
tested with extgw port 443

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ cloud_provider?="aws"
 project?="mojaloop"
 environment?="k3s"
 ingress_name?=nginx
+ext_gw_listen_port?=9443
 monitoring_stack?=efk
 master_instance_type?=m5.large
 master_volume_size?=100
@@ -359,6 +360,7 @@ config: .env ## Run first-time configuration
 	whitelist_ip_file=$$(readConfigVar "whitelist file for external" "whitelist_ip_file" "$(whitelist_ip_file)")
 	vpn_client_ip_file=$$(readConfigVar "whitelist file for external" "vpn_client_ip_file" "$(vpn_client_ip_file)")
 	extra_tag_file=$$(readConfigVar "extra tag file" "extra_tag_file" "$(extra_tag_file)")
+	ext_gw_listen_port=$$(readConfigVar "port that switch extgw listens to" "ext_gw_listen_port" "$(ext_gw_listen_port)")
 	ingress_name=$$(readConfigVar "Ingress controller (nginx or traefik or ambassador)" "ingress_name" "$(ingress_name)")
 	monitoring_stack=$$(readConfigVar "Monitoring stack (efk or loki) [See README if unsure]" "monitoring_stack" "$(monitoring_stack)")
 	letsencrypt_email=$$(readConfigVar "Lets Encrypt Account Email" "letsencrypt_email" "$(letsencrypt_email)")

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -40,6 +40,7 @@ all:
     internal_managed_tls: '{{ internal_managed_tls }}'
     internal_managed_cert_file: '{{ internal_managed_cert_file }}'
     internal_managed_privkey_file: '{{ internal_managed_privkey_file }}'
+    mojaloop_switch_extgw_port: '{{ ext_gw_listen_port }}'
     # --------------
 bastion:
   vars:

--- a/ansible/templates/pm4ml.values.yml.j2
+++ b/ansible/templates/pm4ml.values.yml.j2
@@ -164,10 +164,10 @@ pm4ml-mojaloop-connector:
     JWS_SIGN: true
     JWS_SIGNING_KEY_PATH: /jwsSigningKey/private.key
     VALIDATE_INBOUND_JWS: false
-    PEER_ENDPOINT: "{{ item.value.extgw_fqdn }}:8243/fsp/1.0"
+    PEER_ENDPOINT: "{{ item.value.extgw_fqdn }}:{{ mojaloop_switch_extgw_port }}/fsp/1.0"
     OUTBOUND_MUTUAL_TLS_ENABLED: true
     INBOUND_MUTUAL_TLS_ENABLED: false
-    OAUTH_TOKEN_ENDPOINT: "https://{{ item.value.extgw_fqdn }}:8243/token"
+    OAUTH_TOKEN_ENDPOINT: "https://{{ item.value.extgw_fqdn }}:{{ mojaloop_switch_extgw_port }}/token"
     OAUTH_CLIENT_KEY: "{{ item.value.extgw_client_key }}"
     OAUTH_CLIENT_SECRET: "{{ item.value.extgw_client_secret }}"
     BACKEND_ENDPOINT: "{{ item.value.helm_release_name }}-mojaloop-core-connector:3003"

--- a/terraform/aws/peering.tf
+++ b/terraform/aws/peering.tf
@@ -5,7 +5,7 @@ resource "aws_vpc_peering_connection" "iac_pc" {
   auto_accept = true
 
   accepter {
-    allow_remote_vpc_dns_resolution = true
+    allow_remote_vpc_dns_resolution = false
   }
 
   requester {


### PR DESCRIPTION
parameterize ext gw port
fix peering for int pm4mls to only advertise dns entries from pm4ml vpc to switch, not the other way